### PR TITLE
Align student IDs between backend and frontend

### DIFF
--- a/frontend/src/context/StudentContext.jsx
+++ b/frontend/src/context/StudentContext.jsx
@@ -1,6 +1,6 @@
 /* eslint react-refresh/only-export-components: "off" */
 import {createContext, useState, useEffect} from "react";
-import {addStudent as addStudentService,getStudents} from "../services/studentService";
+import {addStudent as addStudentService,getStudents,updateStudent as updateStudentService,deleteStudent as deleteStudentService} from "../services/studentService";
 export const StudentContext=createContext();
 export const StudentProvider=({children})=>{
     const [students,setStudents]=useState([]);
@@ -9,7 +9,7 @@ export const StudentProvider=({children})=>{
         const fetchStudents=async()=>{
             try{
                 const data=await getStudents();
-                setStudents(data);
+                setStudents(data.map(s=>({...s,id:s._id})));
             }catch(err){
                 console.error(err);
             }
@@ -19,11 +19,23 @@ export const StudentProvider=({children})=>{
 
     const addStudent=async(student)=>{
         const created=await addStudentService(student);
-        setStudents((prev)=>[...prev,created]);
+        const createdWithId={...created,id:created._id};
+        setStudents((prev)=>[...prev,createdWithId]);
+    };
+
+    const updateStudent=async(student)=>{
+        const updated=await updateStudentService(student.id,student);
+        const updatedWithId={...updated,id:updated._id};
+        setStudents((prev)=>prev.map(s=>s.id===student.id?updatedWithId:s));
+    };
+
+    const deleteStudent=async(id)=>{
+        await deleteStudentService(id);
+        setStudents((prev)=>prev.filter(s=>s.id!==id));
     };
 
     return(
-        <StudentContext.Provider value={{students,addStudent}}>
+        <StudentContext.Provider value={{students,addStudent,updateStudent,deleteStudent}}>
             {children}
         </StudentContext.Provider>
     );

--- a/frontend/src/pages/manageStudent.jsx
+++ b/frontend/src/pages/manageStudent.jsx
@@ -46,6 +46,7 @@ function ManageStudents() {
       <DataGrid
         rows={students} // Use students from context
         columns={columns}
+        getRowId={(row) => row._id}
         initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } }}}
         pageSizeOptions={[5, 10]}
         checkboxSelection

--- a/frontend/src/services/studentService.js
+++ b/frontend/src/services/studentService.js
@@ -9,3 +9,13 @@ export const getStudents=async()=>{
     const res=await axios.get("/api/students");
     return res.data;
 };
+
+export const updateStudent = async (id, data) => {
+    const res = await axios.put(`/api/students/${id}`, data);
+    return res.data;
+};
+
+export const deleteStudent = async (id) => {
+    const res = await axios.delete(`/api/students/${id}`);
+    return res.data;
+};


### PR DESCRIPTION

- Map Mongo `_id` to a stable `id` when reading and creating students
- Provide update and delete helpers that preserve the `id` field
- Specify `getRowId` for the student DataGrid to ensure row keys match backend IDs

