### PR TITLE
Handle invalid student responses

### DIFF
--- a/frontend/src/context/StudentContext.jsx
+++ b/frontend/src/context/StudentContext.jsx
@@ -13,15 +13,18 @@ export const StudentProvider = ({ children }) => {
     const [students, setStudents] = useState([]);
 
     useEffect(()=>{
-        const fetchStudents=async()=>{
-            try{
-                const data=await getStudents();
-                setStudents(data.map(s=>({...s,id:s._id})));
-            }catch(err){
-                console.error(err);
+        const fetchStudents = async () => {
+            const data = await getStudents();
+            if (Array.isArray(data)) {
+                setStudents(data.map((s) => ({ ...s, id: s._id })));
+            } else {
+                console.error("Invalid students response:", data);
+                setStudents([]);
             }
         };
-        fetchStudents();
+        fetchStudents().catch((err) => {
+            console.error("Failed to fetch students:", err);
+        });
     },[]);
 
     const addStudent = async (student) => {


### PR DESCRIPTION
## Summary
- Validate student fetch responses before mapping and default to an empty list when invalid
- Surface network or server errors when fetching students

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a768b9c6a0832697525d58565a887c