### PR TITLE
Add faculty dashboard and routing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "./context/authContext";
 import AdminDashboard from "./pages/adminDashboard";
 import ProtectedRoute from "./components/protectedRoute";
 import StudentDashboard from "./pages/studentDashboard";
+import FacultyDashboard from "./pages/facultyDashboard";
 import ManageStudents from "./pages/manageStudent";
 import AddStudent from "./pages/addStudent";
 import EditStudent from "./pages/editStudent";
@@ -23,6 +24,7 @@ function App() {
           <Route path="/register" element={<RegisterPage2 />} />
           <Route path="/login" element={<LoginPage2 />} />
           <Route path="/student-dashboard" element={<ProtectedRoute role="student"><StudentDashboard /></ProtectedRoute>} />
+          <Route path="/faculty-dashboard" element={<ProtectedRoute role="faculty"><FacultyDashboard /></ProtectedRoute>} />
           <Route path="/admin-dashboard" element={<ProtectedRoute role="admin"><AdminDashboard /></ProtectedRoute>} />
           <Route element={<ProtectedRoute role="admin"><StudentProvider><Outlet /></StudentProvider></ProtectedRoute>}>
             <Route path="/admin/students" element={<ManageStudents />} />

--- a/frontend/src/pages/facultyDashboard.jsx
+++ b/frontend/src/pages/facultyDashboard.jsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import { Container, Typography, Button } from '@mui/material';
+import { AuthContext } from '../context/authContext';
+import { useNavigate } from 'react-router-dom';
+
+function FacultyDashboard() {
+  const { user, logout } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <Container maxWidth="lg">
+      <Typography variant="h4" gutterBottom>
+        Welcome, {user?.name}
+      </Typography>
+      <Button variant="contained" color="error" onClick={handleLogout}>
+        Logout
+      </Button>
+    </Container>
+  );
+}
+
+export default FacultyDashboard;


### PR DESCRIPTION
## Summary
- Add `FacultyDashboard` page
- Route faculty users to `/faculty-dashboard`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68a781a292d883269e806baacf26049a