### PR TITLE
Add basic timetable editing interface for admins

### DIFF
--- a/frontend/src/components/TimetableEditor.jsx
+++ b/frontend/src/components/TimetableEditor.jsx
@@ -1,0 +1,137 @@
+import { useState, useEffect } from 'react';
+import {
+  Box,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  Paper,
+  IconButton,
+  TextField,
+  MenuItem,
+  Button,
+} from '@mui/material';
+import { Edit, Save, Close } from '@mui/icons-material';
+import { apiClient } from '../services/api';
+
+const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+const TimetableEditor = ({ refreshKey }) => {
+  const [entries, setEntries] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+  const [formData, setFormData] = useState({ day: '', startTime: '', classroomId: '' });
+
+  useEffect(() => {
+    fetchEntries();
+  }, [refreshKey]);
+
+  const fetchEntries = async () => {
+    try {
+      const res = await apiClient.get('/timetable');
+      setEntries(res.data.timetable || []);
+    } catch (err) {
+      console.error('Failed to fetch timetable', err);
+    }
+  };
+
+  const startEdit = (entry) => {
+    setEditingId(entry._id);
+    setFormData({
+      day: entry.day,
+      startTime: entry.startTime,
+      classroomId: entry.classroomId?._id || '',
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setFormData({ day: '', startTime: '', classroomId: '' });
+  };
+
+  const saveEdit = async () => {
+    try {
+      await apiClient.put(`/timetable/${editingId}`, formData);
+      await fetchEntries();
+    } catch (err) {
+      console.error('Failed to update timetable entry', err);
+    } finally {
+      cancelEdit();
+    }
+  };
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 2 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Course</TableCell>
+            <TableCell>Group</TableCell>
+            <TableCell>Teacher</TableCell>
+            <TableCell>Classroom</TableCell>
+            <TableCell>Day</TableCell>
+            <TableCell>Start Time</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {entries.map((entry) => (
+            <TableRow key={entry._id}>
+              <TableCell>{entry.courseId?.name}</TableCell>
+              <TableCell>{entry.studentGroupId?.name}</TableCell>
+              <TableCell>{entry.teacherId?.name}</TableCell>
+              <TableCell>{entry.classroomId?.name}</TableCell>
+              <TableCell>
+                {editingId === entry._id ? (
+                  <TextField
+                    select
+                    size="small"
+                    value={formData.day}
+                    onChange={(e) => setFormData({ ...formData, day: e.target.value })}
+                  >
+                    {days.map((d) => (
+                      <MenuItem key={d} value={d}>{d}</MenuItem>
+                    ))}
+                  </TextField>
+                ) : (
+                  entry.day
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === entry._id ? (
+                  <TextField
+                    size="small"
+                    value={formData.startTime}
+                    onChange={(e) => setFormData({ ...formData, startTime: e.target.value })}
+                  />
+                ) : (
+                  entry.startTime
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === entry._id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <Button startIcon={<Save />} size="small" onClick={saveEdit} variant="contained">
+                      Save
+                    </Button>
+                    <Button startIcon={<Close />} size="small" onClick={cancelEdit} variant="outlined">
+                      Cancel
+                    </Button>
+                  </Box>
+                ) : (
+                  <IconButton onClick={() => startEdit(entry)} size="small">
+                    <Edit />
+                  </IconButton>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default TimetableEditor;
+

--- a/frontend/src/pages/manageTimetable.jsx
+++ b/frontend/src/pages/manageTimetable.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Box,
   Typography,
@@ -10,12 +10,14 @@ import {
 } from '@mui/material';
 import { Schedule, Add, AutoFixHigh } from '@mui/icons-material';
 import { apiClient } from '../services/api';
+import TimetableEditor from '../components/TimetableEditor';
 
 const ManageTimetable = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [pageError, setPageError] = useState('');
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const handleGenerateTimetable = async () => {
     setLoading(true);
@@ -37,6 +39,7 @@ const ManageTimetable = () => {
           schedule: response.data.schedule
         });
         setSuccess(`Timetable generated successfully! ${response.data.totalSlots} slots created.`);
+        setRefreshKey((k) => k + 1);
       } else {
         setError('No timetable slots could be generated. Please check constraints.');
       }
@@ -123,10 +126,10 @@ const ManageTimetable = () => {
               <Schedule sx={{ mr: 1 }} />
               Current Timetable
             </Typography>
-            <Typography variant="body2" color="textSecondary">
-              Timetable view and editing interface will be displayed here.
+            <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
+              Edit individual timetable entries below.
             </Typography>
-            {/* Timetable grid/calendar view would go here */}
+            <TimetableEditor refreshKey={refreshKey} />
           </Paper>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Summary
- Display generated timetable entries on admin page and allow edits
- Provide TimetableEditor component to fetch and update schedule entries

## Testing
- `npm run lint` (fails: 15 errors, 4 warnings)
- `npm test` in `frontend` (fails: Missing script)
- `npm test` in `backend` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a877136c9c83268ad55c7cc5aa1223