### PR TITLE
feat: add configurable time slot generation

### DIFF
--- a/backend/tests/timeSlotGeneration.test.js
+++ b/backend/tests/timeSlotGeneration.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { generateTimeSlots } = require('../utils/timeSlots');
+
+test('generates slots for 30-minute classes', () => {
+  const slots = generateTimeSlots('09:00', '10:30', 30, 30);
+  assert.deepStrictEqual(slots, ['09:00', '09:30', '10:00']);
+});
+
+test('generates slots that fit 90-minute classes', () => {
+  const slots = generateTimeSlots('09:00', '12:00', 30, 90);
+  assert.deepStrictEqual(slots, ['09:00', '09:30', '10:00', '10:30']);
+});

--- a/backend/utils/timeSlots.js
+++ b/backend/utils/timeSlots.js
@@ -1,0 +1,22 @@
+function toMinutes(time) {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function toTimeString(totalMinutes) {
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+function generateTimeSlots(start = '09:00', end = '17:00', step = 60, duration = step) {
+  const slots = [];
+  const startMin = toMinutes(start);
+  const endMin = toMinutes(end);
+  for (let t = startMin; t + duration <= endMin; t += step) {
+    slots.push(toTimeString(t));
+  }
+  return slots;
+}
+
+module.exports = { generateTimeSlots };


### PR DESCRIPTION

- replace static timetable time slots with configurable generator
- ensure generation uses custom slots and supports arbitrary class durations
- add tests covering 30-minute and 90-minute class scheduling

