### PR TITLE
Persist student group and restrict timetable access

### DIFF
--- a/backend/tests/studentTimetableAccess.test.js
+++ b/backend/tests/studentTimetableAccess.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { timetableRouter } = require('../controllers/timetableController');
+const { studentGroupModel: StudentGroup } = require('../models/studentGroup');
+const { timetableModel: Timetable } = require('../models/timetable');
+
+// Helper to extract the GET / handler
+function getTimetableHandler() {
+  const layer = timetableRouter.stack.find(
+    (l) => l.route && l.route.path === '/' && l.route.methods.get
+  );
+  // index 1 skips authenticateToken middleware
+  return layer.route.stack[1].handle;
+}
+
+const getHandler = getTimetableHandler();
+
+test('student receives timetable for own group only', async () => {
+  // Mock StudentGroup.find to return the student’s group
+  const originalSGFind = StudentGroup.find;
+  StudentGroup.find = async () => [{ _id: 'g1' }];
+
+  // Mock Timetable.find to capture filter and return sample timetable
+  const originalTTFind = Timetable.find;
+  Timetable.find = (filter) => {
+    assert.deepStrictEqual(filter, { studentGroupId: 'g1' });
+    return {
+      populate() { return this; },
+      sort() { return Promise.resolve([{ _id: 'tt1', studentGroupId: 'g1' }]); }
+    };
+  };
+
+  const req = { query: { studentGroupId: 'g1' }, user: { _id: 's1', role: 'student' } };
+  let jsonResponse;
+  const res = { json: (data) => { jsonResponse = data; } };
+
+  await getHandler(req, res);
+
+  assert.deepStrictEqual(jsonResponse, { timetable: [{ _id: 'tt1', studentGroupId: 'g1' }] });
+
+  StudentGroup.find = originalSGFind;
+  Timetable.find = originalTTFind;
+});
+
+test('student cannot access other group timetable', async () => {
+  const originalSGFind = StudentGroup.find;
+  StudentGroup.find = async () => [{ _id: 'g1' }];
+
+  const originalTTFind = Timetable.find;
+  Timetable.find = () => {
+    assert.fail('Timetable.find should not be called');
+  };
+
+  const req = { query: { studentGroupId: 'g2' }, user: { _id: 's1', role: 'student' } };
+  let jsonResponse;
+  const res = { json: (data) => { jsonResponse = data; } };
+
+  await getHandler(req, res);
+
+  assert.deepStrictEqual(jsonResponse, { timetable: [] });
+
+  StudentGroup.find = originalSGFind;
+  Timetable.find = originalTTFind;
+});
+

--- a/frontend/src/context/authContext.jsx
+++ b/frontend/src/context/authContext.jsx
@@ -16,21 +16,28 @@ export const AuthProvider = ({children}) => {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
     const [token, setToken] = useState(null);
+    const [studentGroupId, setStudentGroupId] = useState(null);
     
     useEffect(() => {
         try {
             const storedUser = localStorage.getItem("user");
             const storedToken = localStorage.getItem("token");
-            
+            const storedGroupId = localStorage.getItem("studentGroupId");
+
             if (storedUser && storedUser !== "undefined" && storedToken) {
-                setUser(JSON.parse(storedUser));
+                const parsedUser = JSON.parse(storedUser);
+                setUser(parsedUser);
                 setToken(storedToken);
+                if (parsedUser.role === 'student' && storedGroupId) {
+                    setStudentGroupId(storedGroupId);
+                }
                 axios.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
             }
         } catch (err) {
             console.error("Invalid user data in localStorage:", err);
             localStorage.removeItem("user");
             localStorage.removeItem("token");
+            localStorage.removeItem("studentGroupId");
         } finally {
             setLoading(false);
         }
@@ -39,6 +46,17 @@ export const AuthProvider = ({children}) => {
     const login = (userData, authToken) => {
         setUser(userData);
         setToken(authToken);
+        if (userData.role === 'student') {
+            setStudentGroupId(userData.studentGroupId || null);
+            if (userData.studentGroupId) {
+                localStorage.setItem("studentGroupId", userData.studentGroupId);
+            } else {
+                localStorage.removeItem("studentGroupId");
+            }
+        } else {
+            setStudentGroupId(null);
+            localStorage.removeItem("studentGroupId");
+        }
         localStorage.setItem("user", JSON.stringify(userData));
         localStorage.setItem("token", authToken);
         axios.defaults.headers.common['Authorization'] = `Bearer ${authToken}`;
@@ -47,8 +65,10 @@ export const AuthProvider = ({children}) => {
     const logout = () => {
         setUser(null);
         setToken(null);
+        setStudentGroupId(null);
         localStorage.removeItem("user");
         localStorage.removeItem("token");
+        localStorage.removeItem("studentGroupId");
         delete axios.defaults.headers.common['Authorization'];
     };
 
@@ -68,6 +88,7 @@ export const AuthProvider = ({children}) => {
         <AuthContext.Provider value={{
             user,
             token,
+            studentGroupId,
             loading,
             login,
             logout,

--- a/frontend/src/pages/viewTimetable.jsx
+++ b/frontend/src/pages/viewTimetable.jsx
@@ -53,7 +53,7 @@ const ViewTimetable = () => {
       if (user.role === 'faculty') {
         params.teacherId = user.id;
       } else if (user.role === 'student') {
-        // Student group would be fetched from user profile
+        params.studentGroupId = user.studentGroupId;
       }
 
       const response = await apiClient.get('/timetable', { params });


### PR DESCRIPTION

- Include student group on login responses and persist it in auth context
- Pass studentGroupId when students view timetables and restrict access to their groups
- Add tests ensuring students only receive schedules for their own group

