### PR TITLE
Add count-based timetable constraints

### DIFF
--- a/backend/tests/timetableController.test.js
+++ b/backend/tests/timetableController.test.js
@@ -58,3 +58,16 @@ test('detects classroom conflict in pending schedule', async () => {
   assert(conflicts.some(c => c.includes('Classroom')));
   Timetable.find = originalFind;
 });
+
+test('enforces max daily lectures per teacher', async () => {
+  Timetable.find = mockFindEmpty;
+  const pending = [
+    { teacherId: 't1', studentGroupId: 'sg1', classroomId: 'cl1', day: 'monday', startTime: '08:00', endTime: '09:00' },
+    { teacherId: 't1', studentGroupId: 'sg2', classroomId: 'cl2', day: 'monday', startTime: '09:00', endTime: '10:00' },
+    { teacherId: 't1', studentGroupId: 'sg3', classroomId: 'cl3', day: 'monday', startTime: '10:00', endTime: '11:00' },
+    { teacherId: 't1', studentGroupId: 'sg4', classroomId: 'cl4', day: 'monday', startTime: '11:00', endTime: '12:00' }
+  ];
+  const conflicts = await checkConflicts('c5', 'sg5', 'cl5', 't1', 'monday', '12:00', '13:00', null, pending);
+  assert(conflicts.some(c => c.includes('maximum daily lectures')));
+  Timetable.find = originalFind;
+});

--- a/backend/utils/constraints.js
+++ b/backend/utils/constraints.js
@@ -1,0 +1,35 @@
+const DEFAULT_CONSTRAINTS = {
+  maxTeacherDailyLectures: parseInt(process.env.MAX_TEACHER_DAILY_LECTURES || '4'),
+  maxGroupDailyLectures: parseInt(process.env.MAX_GROUP_DAILY_LECTURES || '5'),
+  maxClassroomDailyLectures: parseInt(process.env.MAX_CLASSROOM_DAILY_LECTURES || '6'),
+};
+
+function checkCountConstraints(allSlots, ids) {
+  const conflicts = [];
+  const { teacherId, studentGroupId, classroomId } = ids;
+
+  if (teacherId) {
+    const teacherCount = allSlots.filter(s => s.teacherId?.toString() === teacherId.toString()).length;
+    if (teacherCount > DEFAULT_CONSTRAINTS.maxTeacherDailyLectures) {
+      conflicts.push(`Teacher exceeds maximum daily lectures of ${DEFAULT_CONSTRAINTS.maxTeacherDailyLectures}`);
+    }
+  }
+
+  if (studentGroupId) {
+    const groupCount = allSlots.filter(s => s.studentGroupId?.toString() === studentGroupId.toString()).length;
+    if (groupCount > DEFAULT_CONSTRAINTS.maxGroupDailyLectures) {
+      conflicts.push(`Student group exceeds maximum daily lectures of ${DEFAULT_CONSTRAINTS.maxGroupDailyLectures}`);
+    }
+  }
+
+  if (classroomId) {
+    const classroomCount = allSlots.filter(s => s.classroomId?.toString() === classroomId.toString()).length;
+    if (classroomCount > DEFAULT_CONSTRAINTS.maxClassroomDailyLectures) {
+      conflicts.push(`Classroom exceeds maximum daily lectures of ${DEFAULT_CONSTRAINTS.maxClassroomDailyLectures}`);
+    }
+  }
+
+  return conflicts;
+}
+
+module.exports = { DEFAULT_CONSTRAINTS, checkCountConstraints };


### PR DESCRIPTION
- enforce configurable limits for daily lectures per teacher, student group, and classroom
- integrate constraint checking into conflict detection logic
- test constraint enforcement for teachers

